### PR TITLE
convert DiskFeedInfoCache to use Paths instead of Strings

### DIFF
--- a/src/test/java/com/rometools/test/DiskFeedInfoCacheTest.java
+++ b/src/test/java/com/rometools/test/DiskFeedInfoCacheTest.java
@@ -1,21 +1,22 @@
 package com.rometools.test;
 
-import java.io.File;
-import java.net.URL;
-
-import junit.framework.TestCase;
-
 import com.rometools.fetcher.impl.DiskFeedInfoCache;
 import com.rometools.fetcher.impl.SyndFeedInfo;
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import junit.framework.TestCase;
 
 public class DiskFeedInfoCacheTest extends TestCase {
 
+    private static final Path TEST_CACHE = Paths.get("test-cache").toAbsolutePath();
     public void testClear() throws Exception {
-        final File cacheDir = new File("test-cache");
+        final File cacheDir = TEST_CACHE.toFile();
         cacheDir.mkdir();
         cacheDir.deleteOnExit();
 
-        final DiskFeedInfoCache cache = new DiskFeedInfoCache(cacheDir.getCanonicalPath());
+        final DiskFeedInfoCache cache = new DiskFeedInfoCache(TEST_CACHE);
         final SyndFeedInfo info = new SyndFeedInfo();
         final URL url = new URL("http://nowhere.com");
         cache.setFeedInfo(url, info);
@@ -30,7 +31,7 @@ public class DiskFeedInfoCacheTest extends TestCase {
         cacheDir.mkdir();
         cacheDir.deleteOnExit();
 
-        final DiskFeedInfoCache cache = new DiskFeedInfoCache(cacheDir.getCanonicalPath());
+        final DiskFeedInfoCache cache = new DiskFeedInfoCache(TEST_CACHE);
         final SyndFeedInfo info = new SyndFeedInfo();
         final URL url = new URL("http://nowhere.com");
         cache.setFeedInfo(url, info);


### PR DESCRIPTION
When dealing with file paths, Strings are ideally avoided wherever possible. java.nio.file.Path has been introduced for this reason, though it does limit backward compatibility to Java 1.7.